### PR TITLE
fix: correctly display rss subscription

### DIFF
--- a/src/components/social-list.astro
+++ b/src/components/social-list.astro
@@ -13,7 +13,7 @@ import IconMdiGithub from "~icons/mdi/github";
 
 <ul class="social-links mt-1">
   <li th:if="${theme.config.social.rss}">
-    <a target="_blank" href="#" title="RSS">
+    <a target="_blank" href="/rss.xml" title="RSS">
       <IconMdiRss class="w-4 h-4" />
     </a>
   </li>


### PR DESCRIPTION
rss 订阅开启的情况下，点击 rss 订阅每次都跳转到首页，修改为正确的 rss 订阅地址

```release-note
None
```